### PR TITLE
Make acc recap use current project by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-07-20
+
 ### Added
 - New `acc recap` command for generating AI-powered worklog summaries with real-time progress updates via SSE streaming
+  - Automatically uses the current project (like `acc log` and `acc logs`) when no project is explicitly specified
+  - Supports filtering by tags with `-t, --tags` flag
+  - Supports excluding entries with specific tags using `-x, --exclude-tags` flag
+  - Supports date filtering with `--from`, `--to`, and `--since` options
 - Server-Sent Events (SSE) support with automatic fallback to polling for robust recap generation
-- Exclude tags support for `acc recap` command with `-x, --exclude-tags` flag for filtering out entries with specific tags
 - Enhanced duration parsing with human-friendly expressions: `yesterday`, `today`, `this-week`, `last-week`, `this-month`, `last-month`
 - Dependabot configuration for automated dependency updates
 
@@ -67,7 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Migrated from version 0.2.0 to 0.1.0 following SemVer conventions for pre-release software
 
-[Unreleased]: https://github.com/typhoonworks/accomplish-cli/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/typhoonworks/accomplish-cli/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/typhoonworks/accomplish-cli/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/typhoonworks/accomplish-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/typhoonworks/accomplish-cli/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/typhoonworks/accomplish/compare/cli-v0.1.1...cli-v0.1.2
 [0.1.1]: https://github.com/typhoonworks/accomplish/compare/cli-v0.1.0...cli-v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "accomplish-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accomplish-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A command-line tool for interacting with the Accomplish platform to log work entries and manage projects."
 authors = ["Rui Freitas <rodloboz@heycom>"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For detailed usage instructions, see the [User Guide](USER_GUIDE.md).
 - `acc logout` - Sign out of your account
 - `acc log` - Record a work entry
 - `acc logs` - View work entries
+- `acc recap` - Generate AI-powered work summaries
 - `acc project` - Manage projects
 - `acc status` - Show current status
 - `acc init` - Initialize configuration

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -67,6 +67,7 @@ acc --help
 acc log --help
 acc project --help
 acc logs --help
+acc recap --help
 ```
 
 Each command shows:
@@ -145,6 +146,38 @@ acc logs --from 2025-01-09 --to 2025-01-16
 
 # Full content view
 acc logs -v
+```
+
+#### `acc recap`
+Generate AI-powered summaries of your work log entries.
+
+**Options:**
+- `-p, --project <PROJECT>`: Filter by project identifier (uses current project by default)
+- `-t, --tags <TAGS>`: Filter by comma-separated tags
+- `-x, --exclude-tags <TAGS>`: Exclude entries with specific tags
+- `--from <DATE>`: Start date (YYYY-MM-DD format)
+- `--to <DATE>`: End date (YYYY-MM-DD format)
+- `--since <PERIOD>`: Time period (e.g., "1d", "1w", "2w", "1m")
+
+**Examples:**
+```bash
+# Generate recap for current project
+acc recap
+
+# Recap for specific project
+acc recap -p ABC
+
+# Recap for last week
+acc recap --since last-week
+
+# Recap for specific date range
+acc recap --from 2025-01-09 --to 2025-01-16
+
+# Recap with specific tags
+acc recap -t backend,api
+
+# Recap excluding certain tags
+acc recap -x meeting,admin
 ```
 
 ### Project Management

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,6 +331,10 @@ async fn main() -> Result<(), AppError> {
                     .collect()
             });
 
+            let resolved_project = project
+                .or_else(|| config::lookup_default_project_for_dir(&env::current_dir().unwrap()))
+                .or(settings.default_project.clone());
+
             if let Err(e) = recap::execute(
                 &mut auth_service,
                 from.as_deref(),
@@ -338,7 +342,7 @@ async fn main() -> Result<(), AppError> {
                 since.as_deref(),
                 processed_tags.as_deref(),
                 processed_exclude_tags.as_deref(),
-                project.as_deref(),
+                resolved_project.as_deref(),
             )
             .await
             {


### PR DESCRIPTION
- acc recap now automatically uses the current project when no project is specified
- Follows the same project resolution as acc log and acc logs commands
- Updates documentation and changelog for v0.4.0 release